### PR TITLE
Add traceparent support on CloudEventFactory builder

### DIFF
--- a/src/main/java/org/eclipse/uprotocol/cloudevent/factory/CloudEventFactory.java
+++ b/src/main/java/org/eclipse/uprotocol/cloudevent/factory/CloudEventFactory.java
@@ -191,6 +191,7 @@ public interface CloudEventFactory {
                 UCloudEvent.getCeName(priority.getValueDescriptor())));
         attributes.hash().ifPresent(hash -> cloudEventBuilder.withExtension("hash", hash));
         attributes.token().ifPresent(token -> cloudEventBuilder.withExtension("token", token));
+        attributes.traceparent().ifPresent(traceparent -> cloudEventBuilder.withExtension("traceparent", traceparent));
 
         return cloudEventBuilder;
     }

--- a/src/test/java/org/eclipse/uprotocol/cloudevent/factory/CloudEventFactoryTest.java
+++ b/src/test/java/org/eclipse/uprotocol/cloudevent/factory/CloudEventFactoryTest.java
@@ -57,6 +57,7 @@ class CloudEventFactoryTest {
                 .withPriority(UPriority.UPRIORITY_CS1)
                 .withTtl(3)
                 .withToken("someOAuthToken")
+                .withTraceparent("myParent")
                 .build();
 
         // build the cloud event
@@ -76,6 +77,7 @@ class CloudEventFactoryTest {
         assertEquals(UCloudEvent.getCePriority(UPriority.UPRIORITY_CS1), cloudEvent.getExtension("priority"));
         assertEquals(3, cloudEvent.getExtension("ttl"));
         assertEquals("someOAuthToken", cloudEvent.getExtension("token"));
+        assertEquals("myParent", cloudEvent.getExtension("traceparent"));
 
         assertArrayEquals(protoPayload.toByteArray(), Objects.requireNonNull(cloudEvent.getData()).toBytes());
     }


### PR DESCRIPTION
to resolve issue #87.

Edited main test to ensure all properties pass.  Existing tests validate the field is correctly handled as optional.