### PR TITLE
Change up-java versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <artifactId>up-java</artifactId>
     <name>Java Library for uProtocol</name>
     <description>Language specific uProtocol library for building and using UUri, UUID, UAttributes, UTransport, and more</description>
-    <version>1.5.9-SNAPSHOT</version>
+    <version>0.1.9-SNAPSHOT</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/up-java/</url>    
 


### PR DESCRIPTION
the current up-java version of 1.5.x was out of sync with the up-core-api/up-spec version numbers so there was confusion on if the two are related meaning is 1.5.7 of up-java the same as 1.5.7 of up-core-api and they are not. In order to avoid confusion, we are renaming the up-java to 0.1.9 and we will add the up-core-api-1.5.7 tag as well so we know what version this support of up-core-api.