### PR TITLE
Fix the uTwin package number

### DIFF
--- a/src/test/java/org/eclipse/uprotocol/uri/factory/UEntityFactoryTest.java
+++ b/src/test/java/org/eclipse/uprotocol/uri/factory/UEntityFactoryTest.java
@@ -32,7 +32,7 @@ import com.google.protobuf.Descriptors.ServiceDescriptor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
  
 import org.eclipse.uprotocol.core.usubscription.v3.USubscriptionProto;
-import org.eclipse.uprotocol.core.utwin.v1.UTwinProto;
+import org.eclipse.uprotocol.core.utwin.v2.UTwinProto;
 import org.eclipse.uprotocol.core.udiscovery.v3.UDiscoveryProto;
 import org.eclipse.uprotocol.v1.UEntity;
 


### PR DESCRIPTION
Incorporate the retagging of uprotocol-core-api-1.5.7 to fix the utwin packaging issue, it was using v1 when it should have been in v2.