### PR TITLE
Add workflow for test coverage report and PR coverage comments

### DIFF
--- a/.github/workflows/coverage-comment-pr.yml
+++ b/.github/workflows/coverage-comment-pr.yml
@@ -1,0 +1,55 @@
+name: Add coverage comment to PR
+
+on:
+  workflow_run:
+    workflows: ["Java Test and Coverage"]
+    types:
+      - completed
+
+jobs:
+  add-coverage-comment:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: 'Download artifact'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: ${{github.event.workflow_run.id }},
+            });
+            var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr-comment"
+            })[0];
+            var download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            var fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/pr-comment.zip', Buffer.from(download.data));
+      - run: unzip pr-comment.zip
+
+      - name: 'Comment on PR'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            var fs = require('fs');
+
+            const issue_number = Number(fs.readFileSync('./pr-number.txt'));
+            const body = fs.readFileSync('./body.txt', { encoding: 'utf8', flag: 'r' });
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue_number,
+              body: body
+            });

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,78 @@
+name: Java Test and Coverage
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test-and-coverage:
+    name: Test with coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - run: |
+          git config --global user.name 'eclipse-uprotocol-bot'
+          git config --global user.email 'uprotocol-bot@eclipse.org'
+
+      - name: Checkout code
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+
+      - name: Set up Apache Maven Central
+        uses: actions/setup-java@v3
+        with: # configure settings.xml
+          distribution: 'temurin'
+          java-version: '11'
+          server-id: ossrh
+          server-username: OSSRH_USER
+          server-password: OSSRH_PASSWORD
+          gpg-private-key: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
+          gpg-passphrase: GPG_PASSPHRASE
+
+
+      - name: Run tests with coverage
+        run: |
+          mvn clean test jacoco:report
+
+
+      - name: Extract JaCoCo report
+        run: |
+          echo "Extracting coverage percentage from JaCoCo report"
+          INDEX_PATH="target/site/jacoco/index.html"
+          export COVERAGE_PERCENTAGE=$(grep -oP '(?<=<td class="ctr2">).*?(?=%</td>)' $INDEX_PATH | sed 's/ //g')
+          export COVERAGE_PERCENTAGE=$(printf "%.2f" "$COVERAGE_PERCENTAGE")
+          echo "COVERAGE_PERCENTAGE= $COVERAGE_PERCENTAGE" >> $GITHUB_ENV
+          echo "COVERAGE_PERCENTAGE: $COVERAGE_PERCENTAGE"
+
+
+      - name: Upload JaCoCo Coverage report
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-report
+          path: target/site/jacoco
+
+      - name: Generate coverage comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const COVERAGE_PERCENTAGE = `${{ env.COVERAGE_PERCENTAGE }}`;
+            const COVERAGE_REPORT_PATH = `https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/`;
+            
+            fs.mkdirSync('./pr-comment', { recursive: true });
+            
+            var pr_number = `${{ github.event.number }}`;
+            var body = `
+              Code coverage report is ready! :chart_with_upwards_trend:
+            
+              - **Code Coverage Percentage:** ${COVERAGE_PERCENTAGE}%
+              - **Code Coverage Report:** [View Coverage Report](${COVERAGE_REPORT_PATH})
+            `;
+            
+            fs.writeFileSync('./pr-comment/pr-number.txt', pr_number);
+            fs.writeFileSync('./pr-comment/body.txt', body);
+
+      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        with:
+          name: pr-comment
+          path: pr-comment/

--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,16 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <includes>
+                        <include>**/cloudevent/**</include>
+                        <include>**/rpc/**</include>
+                        <include>**/transport/**</include>
+                        <include>**/uri/**</include>
+                        <include>**/uuid/**</include>
+                        <include>**/validation/**</include>
+                    </includes>
+                </configuration>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
- Implement workflow to measure test code coverage.
- Generate coverage reports after tests are executed.
- Add support for posting coverage comments on PRs from forks. 

I have tested these workflows in my own fork, keep in mind that this only works once the additional workflow is available in the main branch, thus after this PR has been merged.

Here is the screenshot from my own fork

<img width="614" alt="image" src="https://github.com/eclipse-uprotocol/up-java/assets/7788957/9abecabd-5869-4737-a9af-3bb814c1f6a0">
