### PR TITLE
Fix Priority Validation for UAttributes

### DIFF
--- a/src/main/java/org/eclipse/uprotocol/transport/validate/UAttributesValidator.java
+++ b/src/main/java/org/eclipse/uprotocol/transport/validate/UAttributesValidator.java
@@ -174,7 +174,7 @@ public abstract class UAttributesValidator {
      *         failure message.
      */
     public ValidationResult validatePriority(UAttributes attributes) {
-        return attributes.getPriority().getNumber() >= UPriority.UPRIORITY_CS0_VALUE ? ValidationResult.success()
+        return attributes.getPriority().getNumber() >= UPriority.UPRIORITY_CS1_VALUE ? ValidationResult.success()
                 : ValidationResult.failure(
                         String.format("Invalid UPriority [%s]", attributes.getPriority().name()));
     }

--- a/src/test/java/org/eclipse/uprotocol/transport/validator/UAttributeValidatorTest.java
+++ b/src/test/java/org/eclipse/uprotocol/transport/validator/UAttributeValidatorTest.java
@@ -276,6 +276,20 @@ public class UAttributeValidatorTest {
     }
 
     @Test
+    @DisplayName("Test validatePriority when priority CS0")
+    public void testUAttributeValidatorValidatePriorityIsCS0() {
+        final UMessage message = UMessageBuilder.publish(buildTopicUUri()).build();
+        final UAttributes attributes = UAttributes.newBuilder().
+            mergeFrom(message.getAttributes()).setPriority(UPriority.UPRIORITY_CS0).build();
+        final UAttributesValidator validator = UAttributesValidator.getValidator(attributes);
+        final ValidationResult result = validator.validate(attributes);
+
+        assertTrue(result.isFailure());
+        assertEquals(validator.toString(), "UAttributesValidator.Publish");
+        assertEquals(result.getMessage(), "Invalid UPriority [UPRIORITY_CS0]");
+    }
+
+    @Test
     @DisplayName("Test validateId when id is missing")
     public void testUAttributeValidatorValidateIdMissing() {
         final UMessage message = UMessageBuilder.publish(buildTopicUUri()).build();


### PR DESCRIPTION
Per the specification, UMessages (publish, notification, request, response) MUST have a priority of CS1 or greater but before it was only checking that priority was greater than CS0.

#131