### PR TITLE
Add CallOptions to Notifier & Publisher

### DIFF
--- a/src/main/java/org/eclipse/uprotocol/communication/Notifier.java
+++ b/src/main/java/org/eclipse/uprotocol/communication/Notifier.java
@@ -28,7 +28,7 @@ import org.eclipse.uprotocol.transport.UListener;
 public interface Notifier {
 
     /**
-     * Send a notification to a given topic passing a payload. <br>
+     * Send a notification to a given topic. <br>
      * 
      * @param topic The topic to send the notification to.
      * @param destination The destination to send the notification to.
@@ -39,7 +39,7 @@ public interface Notifier {
     }
 
     /**
-     * Send a notification to a given topic passing a payload. <br>
+     * Send a notification to a given topic with specific {@link CallOptions}. <br>
      * 
      * @param topic The topic to send the notification to.
      * @param destination The destination to send the notification to.
@@ -63,7 +63,7 @@ public interface Notifier {
     }
 
     /**
-     * Send a notification to a given topic passing a payload. <br>
+     * Send a notification to a given topic passing a payload and with specific {@link CallOptions}. <br>
      * 
      * @param topic The topic to send the notification to.
      * @param destination The destination to send the notification to.

--- a/src/main/java/org/eclipse/uprotocol/communication/Notifier.java
+++ b/src/main/java/org/eclipse/uprotocol/communication/Notifier.java
@@ -32,11 +32,46 @@ public interface Notifier {
      * 
      * @param topic The topic to send the notification to.
      * @param destination The destination to send the notification to.
+     * @return Returns the {@link UStatus} with the status of the notification.
+     */
+    default CompletionStage<UStatus> notify(UUri topic, UUri destination) {
+        return notify(topic, destination, null, null);
+    }
+
+    /**
+     * Send a notification to a given topic passing a payload. <br>
+     * 
+     * @param topic The topic to send the notification to.
+     * @param destination The destination to send the notification to.
+     * @param options Call options for the notification.
+     * @return Returns the {@link UStatus} with the status of the notification.
+     */
+    default CompletionStage<UStatus> notify(UUri topic, UUri destination, CallOptions options) {
+        return notify(topic, destination, options, null);
+    }
+
+    /**
+     * Send a notification to a given topic passing a payload. <br>
+     * 
+     * @param topic The topic to send the notification to.
+     * @param destination The destination to send the notification to.
      * @param payload The payload to send with the notification.
      * @return Returns the {@link UStatus} with the status of the notification.
      */
-    CompletionStage<UStatus> notify(UUri topic, UUri destination, UPayload payload);
+    default CompletionStage<UStatus> notify(UUri topic, UUri destination, UPayload payload) {
+        return notify(topic, destination, null, payload);
+    }
 
+    /**
+     * Send a notification to a given topic passing a payload. <br>
+     * 
+     * @param topic The topic to send the notification to.
+     * @param destination The destination to send the notification to.
+     * @param payload The payload to send with the notification.
+     * @param options Call options for the notification.
+     * @return Returns the {@link UStatus} with the status of the notification.
+     */
+    CompletionStage<UStatus> notify(UUri topic, UUri destination, CallOptions options, UPayload payload);
 
     /**
      * Register a listener for a notification topic. <br>
@@ -46,7 +81,6 @@ public interface Notifier {
      * @return Returns the {@link UStatus} with the status of the listener registration.
      */
     CompletionStage<UStatus> registerNotificationListener(UUri topic, UListener listener);
-
 
     /**
      * Unregister a listener from a notification topic. <br>

--- a/src/main/java/org/eclipse/uprotocol/communication/Publisher.java
+++ b/src/main/java/org/eclipse/uprotocol/communication/Publisher.java
@@ -30,8 +30,43 @@ public interface Publisher {
      * Publish a message to a topic passing {@link UPayload} as the payload.
      * 
      * @param topic The topic to publish to.
+     * @param options The {@link CallOptions} for the publish.
      * @param payload The {@link UPayload} to publish.
-     * @return
+     * @return Returns the {@link UStatus} with the status of the publish.
      */
-    CompletionStage<UStatus> publish(UUri topic, UPayload payload);
+    default CompletionStage<UStatus> publish(UUri topic) {
+        return publish(topic, null, null);
+    }
+
+    /**
+     * Publish a message to a topic passing {@link UPayload} as the payload.
+     * 
+     * @param topic The topic to publish to.
+     * @param options The {@link CallOptions} for the publish.
+     * @return Returns the {@link UStatus} with the status of the publish.
+     */
+    default CompletionStage<UStatus> publish(UUri topic, CallOptions options) {
+        return publish(topic, options, null);
+    }
+
+    /**
+     * Publish a message to a topic passing {@link UPayload} as the payload.
+     * 
+     * @param topic The topic to publish to.
+     * @param payload The {@link UPayload} to publish.
+     * @return Returns the {@link UStatus} with the status of the publish.
+     */
+    default CompletionStage<UStatus> publish(UUri topic, UPayload payload) {
+        return publish(topic, null, payload);
+    }
+
+    /**
+     * Publish a message to a topic passing {@link UPayload} as the payload.
+     * 
+     * @param topic The topic to publish to.
+     * @param options The {@link CallOptions} for the publish.
+     * @param payload The {@link UPayload} to publish.
+     * @return Returns the {@link UStatus} with the status of the publish.
+     */
+    CompletionStage<UStatus> publish(UUri topic, CallOptions options, UPayload payload);
 }

--- a/src/main/java/org/eclipse/uprotocol/communication/Publisher.java
+++ b/src/main/java/org/eclipse/uprotocol/communication/Publisher.java
@@ -30,8 +30,6 @@ public interface Publisher {
      * Publish a message to a topic.
      * 
      * @param topic The topic to publish to.
-     * @param options The {@link CallOptions} for the publish.
-     * @param payload The {@link UPayload} to publish.
      * @return Returns the {@link UStatus} with the status of the publish.
      */
     default CompletionStage<UStatus> publish(UUri topic) {

--- a/src/main/java/org/eclipse/uprotocol/communication/Publisher.java
+++ b/src/main/java/org/eclipse/uprotocol/communication/Publisher.java
@@ -27,7 +27,7 @@ import org.eclipse.uprotocol.v1.UUri;
  */
 public interface Publisher {
     /**
-     * Publish a message to a topic passing {@link UPayload} as the payload.
+     * Publish a message to a topic.
      * 
      * @param topic The topic to publish to.
      * @param options The {@link CallOptions} for the publish.
@@ -39,7 +39,7 @@ public interface Publisher {
     }
 
     /**
-     * Publish a message to a topic passing {@link UPayload} as the payload.
+     * Publish a message to a topic with specific {@link CallOptions}
      * 
      * @param topic The topic to publish to.
      * @param options The {@link CallOptions} for the publish.
@@ -61,7 +61,7 @@ public interface Publisher {
     }
 
     /**
-     * Publish a message to a topic passing {@link UPayload} as the payload.
+     * Publish a message to a topic passing {@link UPayload} as the payload and with specific {@link CallOptions}.
      * 
      * @param topic The topic to publish to.
      * @param options The {@link CallOptions} for the publish.

--- a/src/main/java/org/eclipse/uprotocol/communication/SimpleNotifier.java
+++ b/src/main/java/org/eclipse/uprotocol/communication/SimpleNotifier.java
@@ -49,12 +49,18 @@ public class SimpleNotifier  implements Notifier {
      * 
      * @param topic The topic to send the notification to.
      * @param destination The destination to send the notification to.
+     * @param options Call options for the notification.
      * @param payload The payload to send with the notification.
      * @return Returns the {@link UStatus} with the status of the notification.
      */
     @Override
-    public CompletionStage<UStatus> notify(UUri topic, UUri destination, UPayload payload) {
+    public CompletionStage<UStatus> notify(UUri topic, UUri destination, CallOptions options, UPayload payload) {
         UMessageBuilder builder = UMessageBuilder.notification(topic, destination);
+        if (options != null) {
+            builder.withPriority(options.priority());
+            builder.withTtl(options.timeout());
+            builder.withToken(options.token());
+        }
         return transport.send((payload == null) ? builder.build() : 
                 builder.build(payload));
     }

--- a/src/main/java/org/eclipse/uprotocol/communication/SimplePublisher.java
+++ b/src/main/java/org/eclipse/uprotocol/communication/SimplePublisher.java
@@ -46,13 +46,19 @@ public class SimplePublisher implements Publisher {
      * Publish a message to a topic passing {@link UPayload} as the payload.
      * 
      * @param topic The topic to publish to.
+     * @param options The {@link CallOptions} for the publish.
      * @param payload The {@link UPayload} to publish.
-     * @return
+     * @return {@link UStatus} with the result for sending the published message
      */
     @Override
-    public CompletionStage<UStatus> publish(UUri topic, UPayload payload) {
+    public CompletionStage<UStatus> publish(UUri topic, CallOptions options, UPayload payload) {
         Objects.requireNonNull(topic, "Publish topic missing");
         UMessageBuilder builder = UMessageBuilder.publish(topic);
+        if (options != null) {
+            builder.withPriority(options.priority());
+            builder.withTtl(options.timeout());
+            builder.withToken(options.token());
+        }
 
         return transport.send(builder.build(payload));
     }

--- a/src/main/java/org/eclipse/uprotocol/communication/UClient.java
+++ b/src/main/java/org/eclipse/uprotocol/communication/UClient.java
@@ -62,8 +62,8 @@ public class UClient implements RpcServer, Subscriber, Notifier, Publisher, RpcC
     }
 
     @Override
-    public CompletionStage<UStatus> notify(UUri topic, UUri destination, UPayload payload) {
-        return notifier.notify(topic, destination, payload);
+    public CompletionStage<UStatus> notify(UUri topic, UUri destination, CallOptions options, UPayload payload) {
+        return notifier.notify(topic, destination, options, payload);
     }
 
     @Override
@@ -79,8 +79,8 @@ public class UClient implements RpcServer, Subscriber, Notifier, Publisher, RpcC
 
 
     @Override
-    public CompletionStage<UStatus> publish(UUri topic, UPayload payload) {
-        return publisher.publish(topic, payload);
+    public CompletionStage<UStatus> publish(UUri topic, CallOptions options, UPayload payload) {
+        return publisher.publish(topic, options, payload);
     }
 
 

--- a/src/test/java/org/eclipse/uprotocol/communication/NotifierExampleTest.java
+++ b/src/test/java/org/eclipse/uprotocol/communication/NotifierExampleTest.java
@@ -30,7 +30,7 @@ public class NotifierExampleTest {
 
         Notifier notifier = UClient.create(transport);
         // Send the notification (without payload)
-        assertEquals(notifier.notify(topic, destination, null)
+        assertEquals(notifier.notify(topic, destination)
             .toCompletableFuture().get().getCode(), UCode.OK);
     }
 

--- a/src/test/java/org/eclipse/uprotocol/communication/PublisherExampleTest.java
+++ b/src/test/java/org/eclipse/uprotocol/communication/PublisherExampleTest.java
@@ -19,6 +19,6 @@ public class PublisherExampleTest {
 
         Publisher publisher = UClient.create(transport);
         // Send the publish message
-        assertFalse(publisher.publish(topic, null).toCompletableFuture().isCompletedExceptionally());
+        assertFalse(publisher.publish(topic).toCompletableFuture().isCompletedExceptionally());
     }
 }

--- a/src/test/java/org/eclipse/uprotocol/communication/SimpleNotifierTest.java
+++ b/src/test/java/org/eclipse/uprotocol/communication/SimpleNotifierTest.java
@@ -30,7 +30,15 @@ public class SimpleNotifierTest {
     @DisplayName("Test sending a simple notification")
     public void testSendNotification() {
         Notifier notifier = new SimpleNotifier(new TestUTransport());
-        CompletionStage<UStatus> result = notifier.notify(createTopic(), createDestinationUri(), null);
+        CompletionStage<UStatus> result = notifier.notify(createTopic(), createDestinationUri());
+        assertEquals(result.toCompletableFuture().join().getCode(), UCode.OK);
+    }
+
+    @Test
+    @DisplayName("Test sending a simple notification passing CallOptions")
+    public void testSendNotificationWithOptions() {
+        Notifier notifier = new SimpleNotifier(new TestUTransport());
+        CompletionStage<UStatus> result = notifier.notify(createTopic(), createDestinationUri(), CallOptions.DEFAULT);
         assertEquals(result.toCompletableFuture().join().getCode(), UCode.OK);
     }
 
@@ -42,6 +50,16 @@ public class SimpleNotifierTest {
         Notifier notifier = new SimpleNotifier(new TestUTransport());
         CompletionStage<UStatus> result = notifier.notify(createTopic(), createDestinationUri(), 
             UPayload.pack(uri));
+        assertEquals(result.toCompletableFuture().join().getCode(), UCode.OK);
+    }
+
+    @Test
+    @DisplayName("Test sending a simple notification passing a google.protobuf.Any payload and CallOptions")
+    public void testSendNotificationWithAnyPayloadAndOptions() {
+        UUri uri = UUri.newBuilder().setAuthorityName("Hartley").build();
+        Notifier notifier = new SimpleNotifier(new TestUTransport());
+        CompletionStage<UStatus> result = notifier.notify(createTopic(), createDestinationUri(), 
+            CallOptions.DEFAULT, UPayload.packToAny(uri));
         assertEquals(result.toCompletableFuture().join().getCode(), UCode.OK);
     }
 

--- a/src/test/java/org/eclipse/uprotocol/communication/SimplePublisherTest.java
+++ b/src/test/java/org/eclipse/uprotocol/communication/SimplePublisherTest.java
@@ -30,7 +30,15 @@ public class SimplePublisherTest {
     @DisplayName("Test sending a simple publish message without a payload")
     public void testSendPublish() {
         Publisher publisher = new SimplePublisher(new TestUTransport());
-        CompletionStage<UStatus> result = publisher.publish(createTopic(), null);
+        CompletionStage<UStatus> result = publisher.publish(createTopic());
+        assertEquals(result.toCompletableFuture().join().getCode(), UCode.OK);
+    }
+
+    @Test
+    @DisplayName("Test sending a simple publish message with CallOptions and no payload")
+    public void testSendPublishWithOptions() {
+        Publisher publisher = new SimplePublisher(new TestUTransport());
+        CompletionStage<UStatus> result = publisher.publish(createTopic(), CallOptions.DEFAULT);
         assertEquals(result.toCompletableFuture().join().getCode(), UCode.OK);
     }
     
@@ -43,6 +51,14 @@ public class SimplePublisherTest {
         assertEquals(result.toCompletableFuture().join().getCode(), UCode.OK);
     }
 
+    @Test
+    @DisplayName("Test sending a simple publish message with CallOptions and a stuffed UPayload")
+    public void testSendPublishWithPayloadAndOptions() {
+        UUri uri = UUri.newBuilder().setAuthorityName("Hartley").build();
+        Publisher publisher = new SimplePublisher(new TestUTransport());
+        CompletionStage<UStatus> result = publisher.publish(createTopic(), CallOptions.DEFAULT, UPayload.pack(uri));
+        assertEquals(result.toCompletableFuture().join().getCode(), UCode.OK);
+    }
    
     private UUri createTopic() {
         return UUri.newBuilder()

--- a/src/test/java/org/eclipse/uprotocol/communication/UClientTest.java
+++ b/src/test/java/org/eclipse/uprotocol/communication/UClientTest.java
@@ -14,9 +14,7 @@ package org.eclipse.uprotocol.communication;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.eclipse.uprotocol.transport.UListener;
 import org.eclipse.uprotocol.v1.UCode;
 import org.eclipse.uprotocol.v1.UMessage;
@@ -40,10 +38,10 @@ public class UClientTest {
         };
 
         assertDoesNotThrow(() -> 
-            client.notify(createTopic(), createDestinationUri(), null).toCompletableFuture().get());
+            client.notify(createTopic(), createDestinationUri()).toCompletableFuture().get());
         
         assertDoesNotThrow(() -> 
-            client.publish(createTopic(), null).toCompletableFuture().get());
+            client.publish(createTopic()).toCompletableFuture().get());
 
         assertDoesNotThrow(() ->
             client.invokeMethod(createMethodUri(), null, null).toCompletableFuture().get());


### PR DESCRIPTION
CallOptions contains additional attributes that an application might want to set before the message is sent so we pass them to the publish() and notify() APIs. Additionally, I added default APIs for when passed parameters are null (we don't want to pass them).

#130