### PR TITLE
Peg the version of up-spec to v1.6.0-alpha.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <slf4j.version>2.6.18</slf4j.version>
         <cloudevents.version>2.4.2</cloudevents.version>
         <protobuf.version>3.21.10</protobuf.version>
-        <up-spec.git.tag.name>main</up-spec.git.tag.name>
+        <up-spec.git.tag.name>v1.6.0-alpha.2</up-spec.git.tag.name>
     </properties>
 
     <licenses>


### PR DESCRIPTION
In order to ensure the release will pull a stable version, we are setting the version of up-spec to be the latest release version.