### PR TITLE
Address issues in InMemorySubscriber

### DIFF
--- a/src/main/java/org/eclipse/uprotocol/communication/InMemorySubscriber.java
+++ b/src/main/java/org/eclipse/uprotocol/communication/InMemorySubscriber.java
@@ -174,12 +174,13 @@ public class InMemorySubscriber implements Subscriber {
             // Then unregister the listener
             .thenCompose( response ->  {
                 if (response.isSuccess()) {
+                    // Remove the handler only if unsubscribe was successful
+                    mHandlers.remove(topic);
+
                     return transport.unregisterListener(topic, listener);
                 }
                 return CompletableFuture.completedFuture(response.failureValue());
-            })
-            // Remove the handler regardless if unregisterListener() succeeds or not
-            .whenComplete((status, exception) ->  mHandlers.remove(topic));       
+            });
     }
 
 

--- a/src/main/java/org/eclipse/uprotocol/communication/UClient.java
+++ b/src/main/java/org/eclipse/uprotocol/communication/UClient.java
@@ -118,6 +118,5 @@ public class UClient implements RpcServer, Subscriber, Notifier, Publisher, RpcC
     public void close() {
         rpcClient.close();
         subscriber.close();
-        transport.close();
     }
 }

--- a/src/test/java/org/eclipse/uprotocol/uri/validator/UriValidatorTest.java
+++ b/src/test/java/org/eclipse/uprotocol/uri/validator/UriValidatorTest.java
@@ -201,9 +201,17 @@ class UriValidatorTest {
     }
 
     @Test
-    @DisplayName("Matches succeeds for pattern with matching entity instance")
-    public void test_Matches_Succeeds_For_Pattern_With_Matching_Entity_Instance() {
+    @DisplayName("Matches succeeds for pattern with similar entity instance")
+    public void test_Matches_Succeeds_For_Pattern_With_Similar_Entity_Instance() {
         UUri patternUri = UriSerializer.deserialize("//authority/A410/3/1003");
+        UUri candidateUri = UriSerializer.deserialize("//authority/2A410/3/1003");
+        assertTrue(UriValidator.matches(patternUri, candidateUri));
+    }
+
+    @Test
+    @DisplayName("Matches succeeds for pattern with identical entity instance")
+    public void test_Matches_Succeeds_For_Pattern_With_Identical_Entity_Instance() {
+        UUri patternUri = UriSerializer.deserialize("//authority/2A410/3/1003");
         UUri candidateUri = UriSerializer.deserialize("//authority/2A410/3/1003");
         assertTrue(UriValidator.matches(patternUri, candidateUri));
     }


### PR DESCRIPTION
The subscribe API is now idempotent and we fixed unsubscribe() so that there is no issue where we unsubscribe but an handler or listener stays registered.

#140