### PR TITLE
Adding UriFilter

### DIFF
--- a/src/main/java/org/eclipse/uprotocol/uri/validator/UriFilter.java
+++ b/src/main/java/org/eclipse/uprotocol/uri/validator/UriFilter.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.uprotocol.uri.validator;
 
+import org.eclipse.uprotocol.uri.factory.UriFactory;
 import org.eclipse.uprotocol.v1.UAttributes;
 import org.eclipse.uprotocol.v1.UUri;
 
@@ -25,12 +26,14 @@ public record UriFilter(UUri source, UUri sink) {
     /**
      * Constructs a new URI filter with the given source and sink URIs.
      * 
+     * If the source or sink URI is null, it is replaced with the ANY URI.
+     * 
      * @param source The source URI.
      * @param sink The sink URI.
      */
     public UriFilter {
-        Objects.requireNonNull(source);
-        Objects.requireNonNull(sink);
+        source = Objects.requireNonNullElse(source, UriFactory.ANY);
+        sink = Objects.requireNonNullElse(sink, UriFactory.ANY);
     }
     
 
@@ -44,6 +47,13 @@ public record UriFilter(UUri source, UUri sink) {
         if (attributes == null) {
             return false;
         }
-        return UriValidator.matches(source, attributes.getSource()) && UriValidator.matches(sink, attributes.getSink());
+        if (source.equals(UriFactory.ANY)) {
+            return UriValidator.matches(sink, attributes.getSink());
+        } else if (sink.equals(UriFactory.ANY)) {
+            return UriValidator.matches(source, attributes.getSource());
+        } else {
+            return UriValidator.matches(source, attributes.getSource()) &&
+                   UriValidator.matches(sink, attributes.getSink());
+        }
     }
 }

--- a/src/main/java/org/eclipse/uprotocol/uri/validator/UriFilter.java
+++ b/src/main/java/org/eclipse/uprotocol/uri/validator/UriFilter.java
@@ -1,0 +1,49 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.uprotocol.uri.validator;
+
+import org.eclipse.uprotocol.v1.UAttributes;
+import org.eclipse.uprotocol.v1.UUri;
+
+import java.util.Objects;
+
+/**
+ * URI Filter matches URIs based on source and sink URIs.
+ */
+public record UriFilter(UUri source, UUri sink) {
+
+    /**
+     * Constructs a new URI filter with the given source and sink URIs.
+     * 
+     * @param source The source URI.
+     * @param sink The sink URI.
+     */
+    public UriFilter {
+        Objects.requireNonNull(source);
+        Objects.requireNonNull(sink);
+    }
+    
+
+    /**
+     * Matches the given attributes with the source and sink URIs.
+     * 
+     * @param attributes The attributes to match.
+     * @return Returns true if the attributes match the source and sink URIs.
+     */
+    public boolean matches(UAttributes attributes) {
+        if (attributes == null) {
+            return false;
+        }
+        return UriValidator.matches(source, attributes.getSource()) && UriValidator.matches(sink, attributes.getSink());
+    }
+}

--- a/src/test/java/org/eclipse/uprotocol/uri/validator/UriFilterTest.java
+++ b/src/test/java/org/eclipse/uprotocol/uri/validator/UriFilterTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
+import org.eclipse.uprotocol.uri.factory.UriFactory;
 import org.eclipse.uprotocol.v1.UAttributes;
 import org.eclipse.uprotocol.v1.UUri;
 
@@ -32,19 +32,25 @@ public class UriFilterTest {
     @Test
     @DisplayName("Test constructor with null source and sink URIs")
     public void testConstructorWithNullSourceAndSinkURIs() {
-        assertThrows(NullPointerException.class, () -> new UriFilter(null, null));
+        final UriFilter filter = new UriFilter(null, null);
+        assertTrue(filter.source().equals(UriFactory.ANY));
+        assertTrue(filter.sink().equals(UriFactory.ANY));
     }
 
     @Test
     @DisplayName("Test constructor with null source URI")
     public void testConstructorWithNullSourceURI() {
-        assertThrows(NullPointerException.class, () -> new UriFilter(null, UUri.getDefaultInstance()));
+        final UriFilter filter = new UriFilter(null, SINK_URI);
+        assertTrue(filter.source().equals(UriFactory.ANY));
+        assertTrue(filter.sink().equals(SINK_URI));
     }
 
     @Test
     @DisplayName("Test constructor with null sink URI")
     public void testConstructorWithNullSinkURI() {
-        assertThrows(NullPointerException.class, () -> new UriFilter(UUri.getDefaultInstance(), null));
+        final UriFilter filter = new UriFilter(SOURCE_URI, null);
+        assertTrue(filter.source().equals(SOURCE_URI));
+        assertTrue(filter.sink().equals(UriFactory.ANY));
     }
 
     @Test
@@ -109,6 +115,20 @@ public class UriFilterTest {
         UriFilter uriFilter = new UriFilter(SOURCE_URI, SINK_URI);
         assertTrue(SOURCE_URI.equals(uriFilter.source()));
         assertTrue(SINK_URI.equals(uriFilter.sink()));
+    }
+
+    @Test
+    @DisplayName("Test matching when source is UriFactory.ANY and sink is not UriFactory.ANY")
+    public void testMatchingWhenSourceIsUriFactoryAnyAndSinkIsNotUriFactoryAny() {
+        UriFilter uriFilter = new UriFilter(UriFactory.ANY, SINK_URI);
+        assertTrue(uriFilter.matches(UAttributes.newBuilder().setSink(SINK_URI).build()));
+    }
+
+    @Test
+    @DisplayName("Test matching when sink is UriFactory.ANY and source is not UriFactory.ANY")
+    public void testMatchingWhenSinkIsUriFactoryAnyAndSourceIsNotUriFactoryAny() {
+        UriFilter uriFilter = new UriFilter(SOURCE_URI, UriFactory.ANY);
+        assertTrue(uriFilter.matches(UAttributes.newBuilder().setSource(SOURCE_URI).build()));
     }
     
 }

--- a/src/test/java/org/eclipse/uprotocol/uri/validator/UriFilterTest.java
+++ b/src/test/java/org/eclipse/uprotocol/uri/validator/UriFilterTest.java
@@ -1,0 +1,114 @@
+/**
+ * SPDX-FileCopyrightText: 2024 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.eclipse.uprotocol.uri.validator;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.eclipse.uprotocol.v1.UAttributes;
+import org.eclipse.uprotocol.v1.UUri;
+
+
+public class UriFilterTest {
+    private static final UUri SOURCE_URI = UUri.newBuilder().setAuthorityName("source").build();
+    private static final UUri SINK_URI = UUri.newBuilder().setAuthorityName("sink").build();
+    private static final UUri OTHER_URI = UUri.newBuilder().setAuthorityName("other").build();
+
+
+    @Test
+    @DisplayName("Test constructor with null source and sink URIs")
+    public void testConstructorWithNullSourceAndSinkURIs() {
+        assertThrows(NullPointerException.class, () -> new UriFilter(null, null));
+    }
+
+    @Test
+    @DisplayName("Test constructor with null source URI")
+    public void testConstructorWithNullSourceURI() {
+        assertThrows(NullPointerException.class, () -> new UriFilter(null, UUri.getDefaultInstance()));
+    }
+
+    @Test
+    @DisplayName("Test constructor with null sink URI")
+    public void testConstructorWithNullSinkURI() {
+        assertThrows(NullPointerException.class, () -> new UriFilter(UUri.getDefaultInstance(), null));
+    }
+
+    @Test
+    @DisplayName("Test matches with null attributes")
+    public void testMatchesWithNullAttributes() {
+        UriFilter uriFilter = new UriFilter(UUri.getDefaultInstance(), UUri.getDefaultInstance());
+        assertFalse(uriFilter.matches(null));
+    }
+
+    @Test
+    @DisplayName("Test matches with empty source and sink UUri and empty UAttributes")
+    public void testMatchesWithEmptySourceAndSinkUUriAndEmptyUAttributes() {
+        UriFilter uriFilter = new UriFilter(UUri.getDefaultInstance(), UUri.getDefaultInstance());
+        assertTrue(uriFilter.matches(UAttributes.getDefaultInstance()));
+    }
+
+    @Test
+    @DisplayName("Test matches with empty source and sink UUri and non-empty UAttributes")
+    public void testMatchesWithEmptySourceAndSinkUUriAndNonEmptyUAttributes() {
+        UriFilter uriFilter = new UriFilter(UUri.getDefaultInstance(), UUri.getDefaultInstance());
+        assertFalse(uriFilter.matches(UAttributes.newBuilder().setSource(SOURCE_URI).setSink(SOURCE_URI).build()));
+    }
+
+    @Test
+    @DisplayName("Test matches with non-empty source and sink UUri and empty UAttributes")
+    public void testMatchesWithNonEmptySourceAndSinkUUriAndEmptyUAttributes() {
+        UriFilter uriFilter = new UriFilter(SOURCE_URI, SINK_URI);
+        assertFalse(uriFilter.matches(UAttributes.getDefaultInstance()));
+    }
+
+    @Test
+    @DisplayName("Test matches with non-empty source and sink UUri and non-matching UAttributes")
+    public void testMatchesWithNonEmptySourceAndSinkUUriAndNonMatchingUAttributes() {
+        UriFilter uriFilter = new UriFilter(SOURCE_URI, SINK_URI);
+        assertFalse(uriFilter.matches(UAttributes.newBuilder().setSource(OTHER_URI).setSink(OTHER_URI).build()));
+    }
+
+    @Test
+    @DisplayName("Test matches with non-empty source and sink UUri and matching UAttributes")
+    public void testMatchesWithNonEmptySourceAndSinkUUriAndMatchingUAttributes() {
+        UriFilter uriFilter = new UriFilter(SOURCE_URI, SINK_URI);
+        assertTrue(uriFilter.matches(UAttributes.newBuilder().setSource(SOURCE_URI).setSink(SINK_URI).build()));
+    }
+
+    @Test
+    @DisplayName("Test matches source and sink UUri and matching source and non-matching sink UAttributes")
+    public void testMatchesWithNonEmptySourceAndSinkUUriAndMatchingSourceAndNonMatchingSinkUAttributes() {
+        UriFilter uriFilter = new UriFilter(SOURCE_URI, SINK_URI);
+        assertFalse(uriFilter.matches(UAttributes.newBuilder().setSource(SOURCE_URI).setSink(OTHER_URI).build()));
+    }
+
+    @Test
+    @DisplayName("Test matches source and sink UUri and non-matching source and matching sink UAttributes")
+    public void testMatchesWithNonEmptySourceAndSinkUUriAndNonMatchingSourceAndMatchingSinkUAttributes() {
+        UriFilter uriFilter = new UriFilter(SOURCE_URI, SINK_URI);
+        assertFalse(uriFilter.matches(UAttributes.newBuilder().setSource(OTHER_URI).setSink(SINK_URI).build()));
+    }
+
+    @Test
+    @DisplayName("Test fetching the source and sink and verifying they match what was passed to the constructor")
+    public void testFetchingSourceAndSink() {
+        UriFilter uriFilter = new UriFilter(SOURCE_URI, SINK_URI);
+        assertTrue(SOURCE_URI.equals(uriFilter.source()));
+        assertTrue(SINK_URI.equals(uriFilter.sink()));
+    }
+    
+}


### PR DESCRIPTION
The UriFilter class is used to match a source and sink URI to UAttributes that is passed. This can be used within a transport to match incoming messages

#147