### PR TITLE
Fix version in maven central and follow SEMVER requirements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <artifactId>up-java</artifactId>
     <name>Java Library for uProtocol</name>
     <description>Language specific uProtocol library for building and using UUri, UUID, UAttributes, UTransport, and more</description>
-    <version>0.2.1-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <url>https://github.com/eclipse-uprotocol/up-java/</url>    
 


### PR DESCRIPTION
up-java pre-dates open sourcing uProtocol. Initial releases to maven central took on the up-spec version numbering which led to confusion as the patch number of up-java wasn't a direct correlation with the specifications. The decision was made (to fast) to then switch to 0.x.x for up-java however this further confused folks who go to maven central and see that v0.x is newer than v1.x.

To clean this up, we will switch up-java to version 2.x.x and moving forward, we will follow SEMVER requirements for major, minor, and patch updates.

#166