### PR TITLE
Remove SubscriptionChangeHandler from unregisterForNotifications

### DIFF
--- a/src/main/java/org/eclipse/uprotocol/client/usubscription/v3/InMemoryUSubscriptionClient.java
+++ b/src/main/java/org/eclipse/uprotocol/client/usubscription/v3/InMemoryUSubscriptionClient.java
@@ -295,7 +295,6 @@ public class InMemoryUSubscriptionClient implements USubscriptionClient {
      * Unregister for subscription change notifications.
      * 
      * @param topic The topic to unregister for notifications.
-     * @param handler The {@link SubscriptionChangeHandler} to handle the subscription changes.
      * @param options The {@link CallOptions} to be used for the unregister request.
      * @return {@link CompletionStage} completed successfully with {@link NotificationResponse} with
      *         the status of the API call to uSubscription service, or completed unsuccessfully with
@@ -303,10 +302,8 @@ public class InMemoryUSubscriptionClient implements USubscriptionClient {
      *         returned if the topic ue_id does not equal the callers ue_id. 
      */
     @Override
-    public CompletionStage<NotificationsResponse> unregisterForNotifications(UUri topic,
-        SubscriptionChangeHandler handler, CallOptions options) {
+    public CompletionStage<NotificationsResponse> unregisterForNotifications(UUri topic, CallOptions options) {
         Objects.requireNonNull(topic, "Topic missing");
-        Objects.requireNonNull(handler, "Handler missing");
         Objects.requireNonNull(options, "CallOptions missing");
         
         NotificationsRequest request = NotificationsRequest.newBuilder()

--- a/src/main/java/org/eclipse/uprotocol/client/usubscription/v3/USubscriptionClient.java
+++ b/src/main/java/org/eclipse/uprotocol/client/usubscription/v3/USubscriptionClient.java
@@ -177,14 +177,12 @@ public interface USubscriptionClient {
      * Unregister for subscription change notifications.
      * 
      * @param topic The topic to unregister for notifications.
-     * @param handler The {@link SubscriptionChangeHandler} to be unregistered.
      * @return {@link CompletionStage} completed successfully with {@link NotificationResponse} with
      *         the status of the API call to uSubscription service, or completed unsuccessfully with
      *         {@link UStatus} with the reason for the failure. 
      */
-    default CompletionStage<NotificationsResponse> unregisterForNotifications(UUri topic, 
-        SubscriptionChangeHandler handler) {
-        return unregisterForNotifications(topic, handler, CallOptions.DEFAULT);
+    default CompletionStage<NotificationsResponse> unregisterForNotifications(UUri topic) {
+        return unregisterForNotifications(topic, CallOptions.DEFAULT);
     }
 
 
@@ -192,14 +190,12 @@ public interface USubscriptionClient {
      * Unregister for subscription change notifications.
      * 
      * @param topic The topic to unregister for notifications.
-     * @param handler The {@link SubscriptionChangeHandler} to be unregistered.
      * @param options The {@link CallOptions} to be used for the request.
      * @return {@link CompletionStage} completed successfully with {@link NotificationResponse} with
      *         the status of the API call to uSubscription service, or completed unsuccessfully with
      *         {@link UStatus} with the reason for the failure. 
      */
-    CompletionStage<NotificationsResponse> unregisterForNotifications(UUri topic, SubscriptionChangeHandler handler,
-        CallOptions options);
+    CompletionStage<NotificationsResponse> unregisterForNotifications(UUri topic, CallOptions options);
 
 
     /**

--- a/src/test/java/org/eclipse/uprotocol/client/usubscription/v3/InMemoryUSubscriptionClientTest.java
+++ b/src/test/java/org/eclipse/uprotocol/client/usubscription/v3/InMemoryUSubscriptionClientTest.java
@@ -100,7 +100,7 @@ public class InMemoryUSubscriptionClientTest {
             .thenReturn(CompletableFuture.completedFuture(UStatus.newBuilder().setCode(UCode.OK).build()));
 
         assertDoesNotThrow(() -> {
-            InMemoryUSubscriptionClient subscriber = new InMemoryUSubscriptionClient(transport);
+            new InMemoryUSubscriptionClient(transport);
         });
 
         verify(transport, times(2)).getSource();
@@ -112,7 +112,7 @@ public class InMemoryUSubscriptionClientTest {
     @DisplayName("Testing creation of InMemoryUSubscriptionClient passing null for the transport")
     public void test_creation_of_InMemoryUSubscriptionClient_passing_null_for_the_transport() {
         assertThrows(NullPointerException.class, () -> {
-            InMemoryUSubscriptionClient subscriber = new InMemoryUSubscriptionClient(null);
+            new InMemoryUSubscriptionClient(null);
         });
     }
 
@@ -902,15 +902,6 @@ public class InMemoryUSubscriptionClientTest {
 
         InMemoryUSubscriptionClient subscriber = new InMemoryUSubscriptionClient(transport, rpcClient, notifier);
         assertNotNull(subscriber);
-
-        SubscriptionChangeHandler handler = new SubscriptionChangeHandler() {
-            @Override
-            public void handleSubscriptionChange(UUri topic, SubscriptionStatus status) {
-                // TODO Auto-generated method stub
-                throw new UnsupportedOperationException("Unimplemented method 'handleSubscriptionChange'");
-            }
-        };
-
         UListener listener = new UListener() {
             @Override
             public void onReceive(UMessage message) {
@@ -1113,7 +1104,7 @@ public class InMemoryUSubscriptionClientTest {
 
         assertDoesNotThrow(() -> {
             subscriber.registerForNotifications(topic, handler).toCompletableFuture().get();
-            subscriber.unregisterForNotifications(topic, handler).toCompletableFuture().get();
+            subscriber.unregisterForNotifications(topic).toCompletableFuture().get();
         });
 
         verify(notifier, times(1)).registerNotificationListener(any(), any());
@@ -1129,16 +1120,8 @@ public class InMemoryUSubscriptionClientTest {
         InMemoryUSubscriptionClient subscriber = new InMemoryUSubscriptionClient(transport, rpcClient, notifier);
         assertNotNull(subscriber);
 
-        SubscriptionChangeHandler handler = new SubscriptionChangeHandler() {
-            @Override
-            public void handleSubscriptionChange(UUri topic, SubscriptionStatus status) {
-                // TODO Auto-generated method stub
-                throw new UnsupportedOperationException("Unimplemented method 'handleSubscriptionChange'");
-            }
-        };
-
-        assertThrows(NullPointerException.class, () -> {
-            subscriber.unregisterForNotifications(null, handler);
+         assertThrows(NullPointerException.class, () -> {
+            subscriber.unregisterForNotifications(null);
         });
 
         verify(notifier, times(1)).registerNotificationListener(any(), any());
@@ -1176,17 +1159,10 @@ public class InMemoryUSubscriptionClientTest {
         InMemoryUSubscriptionClient subscriber = new InMemoryUSubscriptionClient(transport, rpcClient, notifier);
         assertNotNull(subscriber);
 
-        SubscriptionChangeHandler handler = new SubscriptionChangeHandler() {
-            @Override
-            public void handleSubscriptionChange(UUri topic, SubscriptionStatus status) {
-                // TODO Auto-generated method stub
-                throw new UnsupportedOperationException("Unimplemented method 'handleSubscriptionChange'");
-            }
-        };
         UUri topic = UUri.newBuilder(transport.getSource()).setResourceId(0x8000).build();
 
         assertDoesNotThrow(() -> {
-            CompletionStage<NotificationsResponse> response = subscriber.unregisterForNotifications(topic, handler);
+            CompletionStage<NotificationsResponse> response = subscriber.unregisterForNotifications(topic);
             assertTrue(response.toCompletableFuture().isCompletedExceptionally());
 
             response.handle((r, e) -> {


### PR DESCRIPTION
The passed handler is not used or needed so removing this attribute.

#177