### PR TITLE
Improve UTransport interface

### DIFF
--- a/src/main/java/org/eclipse/uprotocol/communication/InMemoryRpcClient.java
+++ b/src/main/java/org/eclipse/uprotocol/communication/InMemoryRpcClient.java
@@ -68,7 +68,7 @@ public class InMemoryRpcClient extends AbstractCommunicationLayerClient implemen
 
         getTransport().registerListener(
                 UriFactory.ANY,
-                getUriProvider().getSource(),
+                Optional.of(getUriProvider().getSource()),
                 mResponseHandler)
             .toCompletableFuture().join();
     }
@@ -125,7 +125,10 @@ public class InMemoryRpcClient extends AbstractCommunicationLayerClient implemen
      */
     public void close() {
         mRequests.clear();
-        getTransport().unregisterListener(UriFactory.ANY, getUriProvider().getSource(), mResponseHandler);
+        getTransport().unregisterListener(
+            UriFactory.ANY,
+            Optional.of(getUriProvider().getSource()),
+            mResponseHandler);
     }
 
     private void handleResponse(UMessage message) {

--- a/src/main/java/org/eclipse/uprotocol/communication/InMemoryRpcServer.java
+++ b/src/main/java/org/eclipse/uprotocol/communication/InMemoryRpcServer.java
@@ -112,7 +112,7 @@ public class InMemoryRpcServer extends AbstractCommunicationLayerClient implemen
                 return CompletableFuture.failedFuture(new UStatusException(
                     UCode.ALREADY_EXISTS, "Handler already registered"));
             }
-            return getTransport().registerListener(UriFactory.ANY, method, mRequestHandler)
+            return getTransport().registerListener(UriFactory.ANY, Optional.of(method), mRequestHandler)
                 .whenComplete((ok, throwable) -> {
                     if (throwable != null) {
                         mRequestsHandlers.remove(method);
@@ -140,7 +140,7 @@ public class InMemoryRpcServer extends AbstractCommunicationLayerClient implemen
         }
 
         if (mRequestsHandlers.remove(method, handler)) {
-            return getTransport().unregisterListener(UriFactory.ANY, method, mRequestHandler);
+            return getTransport().unregisterListener(UriFactory.ANY, Optional.of(method), mRequestHandler);
         } else {
             return CompletableFuture.failedFuture(new UStatusException(
                 UCode.NOT_FOUND, "Handler not found"));

--- a/src/main/java/org/eclipse/uprotocol/communication/SimpleNotifier.java
+++ b/src/main/java/org/eclipse/uprotocol/communication/SimpleNotifier.java
@@ -13,6 +13,7 @@
 package org.eclipse.uprotocol.communication;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
@@ -64,11 +65,11 @@ public class SimpleNotifier extends AbstractCommunicationLayerClient implements 
 
     @Override
     public CompletionStage<Void> registerNotificationListener(UUri topic, UListener listener) {
-        return getTransport().registerListener(topic, getUriProvider().getSource(), listener);
+        return getTransport().registerListener(topic, Optional.of(getUriProvider().getSource()), listener);
     }
 
     @Override
     public CompletionStage<Void> unregisterNotificationListener(UUri topic, UListener listener) {
-        return getTransport().unregisterListener(topic, getUriProvider().getSource(), listener);
+        return getTransport().unregisterListener(topic, Optional.of(getUriProvider().getSource()), listener);
     }
 }

--- a/src/main/java/org/eclipse/uprotocol/transport/UTransport.java
+++ b/src/main/java/org/eclipse/uprotocol/transport/UTransport.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.uprotocol.transport;
 
+import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 
 import org.eclipse.uprotocol.communication.UStatusException;
@@ -38,6 +39,7 @@ public interface UTransport {
      *                {@link UAttributes} contained in the message determine the addressing semantics.
      * @return The outcome of the operation. The stage will be completed with a {@link UStatusException} if
      * the message could not be sent.
+     * @throws NullPointerException if the argument is {@code null}.
      */
     CompletionStage<Void> send(UMessage message);
 
@@ -49,17 +51,19 @@ public interface UTransport {
      * <a href="https://github.com/eclipse-uprotocol/up-spec/blob/v1.6.0-alpha.6/basics/uri.adoc">UUri
      * specification</a>.
      * <p>
-     * This default implementation invokes {@link #registerListener(UUri, UUri, UListener)} with the
+     * This default implementation invokes {@link #registerListener(UUri, Optional<UUri>, UListener)} with the
      * given source filter and a sink filter of {@link UriFactory#ANY}.
      *
      * @param sourceFilter The <em>source</em> address pattern that messages need to match.
+     * Use {@link UriFactory#ANY} to match any source.
      * @param listener     The listener to invoke. The listener can be unregistered again
-     * using {@link #unregisterListener(UUri, UUri, UListener)}.
+     * using {@link #unregisterListener(UUri, UListener)}.
      * @return The outcome of the operation. The stage will be completed with a {@link UStatusException} if
      * the listener could not be registered.
+     * @throws NullPointerException if any of the arguments are {@code null}.
      */
     default CompletionStage<Void> registerListener(UUri sourceFilter, UListener listener) {
-        return registerListener(sourceFilter, UriFactory.ANY, listener);
+        return registerListener(sourceFilter, Optional.of(UriFactory.ANY), listener);
     }
 
     /**
@@ -71,36 +75,40 @@ public interface UTransport {
      * specification</a>.
      *
      * @param sourceFilter The <em>source</em> address pattern that messages need to match.
+     * Use {@link UriFactory#ANY} to match any source.
      * @param sinkFilter   The <em>sink</em> address pattern that messages need to match.
+     * Use {@link UriFactory#ANY} to match any sink. Use {@link Optional#empty()} to match only messages without a sink.
      * @param listener     The listener to invoke. The listener can be unregistered again
-     * using {@link #unregisterListener(UUri, UUri, UListener)}.
+     * using {@link #unregisterListener(UUri, Optional<UUri>, UListener)}.
      * @return The outcome of the operation. The stage will be completed with a {@link UStatusException} if
      * the listener could not be registered.
+     * @throws NullPointerException if any of the arguments are {@code null}.
      */
-    CompletionStage<Void> registerListener(UUri sourceFilter, UUri sinkFilter, UListener listener);
+    CompletionStage<Void> registerListener(UUri sourceFilter, Optional<UUri> sinkFilter, UListener listener);
 
     /**
-     * Unregisters a message listener.
+     * Unregisters a previously {@link #registerListener(UUri, UListener) registered} message listener.
      * <p>
-     * The listener will no longer be called for any (matching) messages after this function has
+     * The listener will no longer be called for any (matching) messages after this method has
      * returned successfully.
      * <p>
-     * This default implementation invokes {@link #unregisterListener(UUri, UUri, UListener)} with the
+     * This default implementation invokes {@link #unregisterListener(UUri, Optional<UUri>, UListener)} with the
      * given source filter and a sink filter of {@link UriFactory#ANY}.
      *
      * @param sourceFilter The <em>source</em> address pattern that the listener had been registered for.
      * @param listener      The listener to unregister.
      * @return The outcome of the operation. The stage will be completed with a {@link UStatusException} if
      * the listener could not be unregistered.
+     * @throws NullPointerException if any of the arguments are {@code null}.
      */
     default CompletionStage<Void> unregisterListener(UUri sourceFilter, UListener listener) {
-        return unregisterListener(sourceFilter, UriFactory.ANY, listener);
+        return unregisterListener(sourceFilter, Optional.of(UriFactory.ANY), listener);
     }
 
     /**
-     * Unregisters a message listener.
+     * Unregisters a previously {@link #registerListener(UUri, Optional<UUri>, UListener) registered} message listener.
      * <p>
-     * The listener will no longer be called for any (matching) messages after this function has
+     * The listener will no longer be called for any (matching) messages after this method has
      * returned successfully.
      *
      * @param sourceFilter The <em>source</em> address pattern that the listener had been registered for.
@@ -108,6 +116,7 @@ public interface UTransport {
      * @param listener      The listener to unregister.
      * @return The outcome of the operation. The stage will be completed with a {@link UStatusException} if
      * the listener could not be unregistered.
+     * @throws NullPointerException if any of the arguments are {@code null}.
      */
-    CompletionStage<Void> unregisterListener(UUri sourceFilter, UUri sinkFilter, UListener listener);
+    CompletionStage<Void> unregisterListener(UUri sourceFilter, Optional<UUri> sinkFilter, UListener listener);
 }

--- a/src/main/java/org/eclipse/uprotocol/validation/ValidationUtils.java
+++ b/src/main/java/org/eclipse/uprotocol/validation/ValidationUtils.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: 2024 Contributors to the Eclipse Foundation
+ * SPDX-FileCopyrightText: 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/src/test/java/org/eclipse/uprotocol/communication/CommunicationLayerClientTestBase.java
+++ b/src/test/java/org/eclipse/uprotocol/communication/CommunicationLayerClientTestBase.java
@@ -15,6 +15,7 @@ package org.eclipse.uprotocol.communication;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.uprotocol.transport.LocalUriProvider;
@@ -54,11 +55,12 @@ class CommunicationLayerClientTestBase {
     protected ArgumentCaptor<UMessage> requestMessage;
 
     @BeforeEach
+    @SuppressWarnings("unchecked")
     void setUpTransport() {
         transport = mock(UTransport.class);
-        Mockito.lenient().when(transport.registerListener(any(UUri.class), any(UUri.class), any(UListener.class)))
+        Mockito.lenient().when(transport.registerListener(any(UUri.class), any(Optional.class), any(UListener.class)))
             .thenReturn(CompletableFuture.completedFuture(null));
-        Mockito.lenient().when(transport.unregisterListener(any(UUri.class), any(UUri.class), any(UListener.class)))
+        Mockito.lenient().when(transport.unregisterListener(any(UUri.class), any(Optional.class), any(UListener.class)))
             .thenReturn(CompletableFuture.completedFuture(null));
         Mockito.lenient().when(transport.send(any(UMessage.class)))
             .thenReturn(CompletableFuture.completedFuture(null));

--- a/src/test/java/org/eclipse/uprotocol/communication/InMemoryRpcServerTest.java
+++ b/src/test/java/org/eclipse/uprotocol/communication/InMemoryRpcServerTest.java
@@ -103,7 +103,7 @@ class InMemoryRpcServerTest extends CommunicationLayerClientTestBase {
             .join();
         verify(transport).registerListener(
             eq(originFilter),
-            eq(METHOD_URI),
+            eq(Optional.of(METHOD_URI)),
             any(UListener.class));
 
         server.unregisterRequestHandler(
@@ -114,7 +114,7 @@ class InMemoryRpcServerTest extends CommunicationLayerClientTestBase {
             .join();
         verify(transport).unregisterListener(
             eq(originFilter),
-            eq(METHOD_URI),
+            eq(Optional.of(METHOD_URI)),
             any(UListener.class));
     }
 
@@ -132,7 +132,7 @@ class InMemoryRpcServerTest extends CommunicationLayerClientTestBase {
             .join();
         verify(transport, times(1)).registerListener(
             eq(originFilter),
-            eq(METHOD_URI),
+            eq(Optional.of(METHOD_URI)),
             any(UListener.class));
 
         var exception = assertThrows(CompletionException.class, () -> server.registerRequestHandler(
@@ -146,6 +146,7 @@ class InMemoryRpcServerTest extends CommunicationLayerClientTestBase {
 
     @Test
     @DisplayName("Test unregistering a request handler that wasn't registered already")
+    @SuppressWarnings("unchecked")
     void testUnregisterRequestHandlerFailsForUnknownHandler() {
         final RpcServer server = new InMemoryRpcServer(transport, uriProvider);
 
@@ -156,14 +157,15 @@ class InMemoryRpcServerTest extends CommunicationLayerClientTestBase {
         assertEquals(UCode.NOT_FOUND, ((UStatusException) exception.getCause()).getCode());
         verify(transport, never()).unregisterListener(
             any(UUri.class),
-            any(UUri.class),
+            any(Optional.class),
             any(UListener.class));
     }
 
     @Test
     @DisplayName("Test registering a request handler with unavailable transport fails")
+    @SuppressWarnings("unchecked")
     void testRegisteringRequestListenerFailsIfTransportIsUnavailable() {
-        when(transport.registerListener(any(UUri.class), any(UUri.class), any(UListener.class)))
+        when(transport.registerListener(any(UUri.class), any(Optional.class), any(UListener.class)))
             .thenReturn(CompletableFuture.failedFuture(new UStatusException(UCode.UNAVAILABLE, "unavailable")));
         RpcServer server = new InMemoryRpcServer(transport, uriProvider);
 
@@ -174,7 +176,7 @@ class InMemoryRpcServerTest extends CommunicationLayerClientTestBase {
         assertEquals(UCode.UNAVAILABLE, ((UStatusException) exception.getCause()).getCode());
         verify(transport, times(1)).registerListener(
             eq(UriFactory.ANY),
-            eq(METHOD_URI),
+            eq(Optional.of(METHOD_URI)),
             any(UListener.class));
     }
 
@@ -203,7 +205,7 @@ class InMemoryRpcServerTest extends CommunicationLayerClientTestBase {
         server.registerRequestHandler(UriFactory.ANY, METHOD_URI.getResourceId(), handler)
             .toCompletableFuture().join();
         final ArgumentCaptor<UListener> requestListener = ArgumentCaptor.forClass(UListener.class);
-        verify(transport).registerListener(eq(UriFactory.ANY), eq(METHOD_URI), requestListener.capture());
+        verify(transport).registerListener(eq(UriFactory.ANY), eq(Optional.of(METHOD_URI)), requestListener.capture());
 
         final var request = UMessageBuilder.request(uriProvider.getSource(), METHOD_URI, 5000).build();
         requestListener.getValue().onReceive(request);
@@ -260,7 +262,7 @@ class InMemoryRpcServerTest extends CommunicationLayerClientTestBase {
         server.registerRequestHandler(UriFactory.ANY, METHOD_URI.getResourceId(), handler)
             .toCompletableFuture().join();
         final ArgumentCaptor<UListener> requestListener = ArgumentCaptor.forClass(UListener.class);
-        verify(transport).registerListener(eq(UriFactory.ANY), eq(METHOD_URI), requestListener.capture());
+        verify(transport).registerListener(eq(UriFactory.ANY), eq(Optional.of(METHOD_URI)), requestListener.capture());
 
         requestListener.getValue().onReceive(request);
         verify(handler).handleRequest(request);
@@ -290,7 +292,7 @@ class InMemoryRpcServerTest extends CommunicationLayerClientTestBase {
         server.registerRequestHandler(UriFactory.ANY, METHOD_URI.getResourceId(), handler)
             .toCompletableFuture().join();
         final ArgumentCaptor<UListener> requestListener = ArgumentCaptor.forClass(UListener.class);
-        verify(transport).registerListener(eq(UriFactory.ANY), eq(METHOD_URI), requestListener.capture());
+        verify(transport).registerListener(eq(UriFactory.ANY), eq(Optional.of(METHOD_URI)), requestListener.capture());
 
         server.unregisterRequestHandler(UriFactory.ANY, METHOD_URI.getResourceId(), handler)
             .toCompletableFuture().join();
@@ -326,7 +328,7 @@ class InMemoryRpcServerTest extends CommunicationLayerClientTestBase {
         server.registerRequestHandler(UriFactory.ANY, METHOD_URI.getResourceId(), handler)
             .toCompletableFuture().join();
         final ArgumentCaptor<UListener> requestListener = ArgumentCaptor.forClass(UListener.class);
-        verify(transport).registerListener(eq(UriFactory.ANY), eq(METHOD_URI), requestListener.capture());
+        verify(transport).registerListener(eq(UriFactory.ANY), eq(Optional.of(METHOD_URI)), requestListener.capture());
 
         requestListener.getValue().onReceive(invalidNotification);
         verify(handler, never()).handleRequest(any(UMessage.class));
@@ -349,7 +351,7 @@ class InMemoryRpcServerTest extends CommunicationLayerClientTestBase {
         server.registerRequestHandler(UriFactory.ANY, METHOD_URI.getResourceId(), handler)
             .toCompletableFuture().join();
         final ArgumentCaptor<UListener> requestListener = ArgumentCaptor.forClass(UListener.class);
-        verify(transport).registerListener(eq(UriFactory.ANY), eq(METHOD_URI), requestListener.capture());
+        verify(transport).registerListener(eq(UriFactory.ANY), eq(Optional.of(METHOD_URI)), requestListener.capture());
 
         requestListener.getValue().onReceive(request);
         verify(handler).handleRequest(request);

--- a/src/test/java/org/eclipse/uprotocol/communication/InMemorySubscriberTest.java
+++ b/src/test/java/org/eclipse/uprotocol/communication/InMemorySubscriberTest.java
@@ -102,15 +102,16 @@ class InMemorySubscriberTest {
     private UListener listener;
 
     @BeforeEach
+    @SuppressWarnings("unchecked")
     void setup() {
         uriProvider = StaticUriProvider.of(SOURCE);
 
         transport = mock(UTransport.class);
-        Mockito.lenient().when(transport.registerListener(any(UUri.class), any(UUri.class), any(UListener.class)))
+        Mockito.lenient().when(transport.registerListener(any(UUri.class), any(Optional.class), any(UListener.class)))
             .thenReturn(CompletableFuture.completedFuture(null));
         Mockito.lenient().when(transport.registerListener(any(UUri.class), any(UListener.class)))
             .thenReturn(CompletableFuture.completedFuture(null));
-        Mockito.lenient().when(transport.unregisterListener(any(UUri.class), any(UUri.class), any(UListener.class)))
+        Mockito.lenient().when(transport.unregisterListener(any(UUri.class), any(Optional.class), any(UListener.class)))
             .thenReturn(CompletableFuture.completedFuture(null));
         Mockito.lenient().when(transport.unregisterListener(any(UUri.class), any(UListener.class)))
             .thenReturn(CompletableFuture.completedFuture(null));
@@ -186,7 +187,7 @@ class InMemorySubscriberTest {
             SUBSCRIPTION_NOTIFICATION_TOPIC_URI.getAuthorityName());
         verify(transport).registerListener(
             eq(SUBSCRIPTION_NOTIFICATION_TOPIC_URI),
-            eq(SOURCE),
+            eq(Optional.of(SOURCE)),
             any(UListener.class));
     }
 

--- a/src/test/java/org/eclipse/uprotocol/communication/SimpleNotifierTest.java
+++ b/src/test/java/org/eclipse/uprotocol/communication/SimpleNotifierTest.java
@@ -15,10 +15,12 @@ package org.eclipse.uprotocol.communication;
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
@@ -103,20 +105,21 @@ class SimpleNotifierTest extends CommunicationLayerClientTestBase {
         notifier.registerNotificationListener(TOPIC_URI, listener).toCompletableFuture().join();
         verify(transport).registerListener(
             TOPIC_URI,
-            TRANSPORT_SOURCE,
+            Optional.of(TRANSPORT_SOURCE),
             listener);
         notifier.unregisterNotificationListener(TOPIC_URI, listener).toCompletableFuture().join();
         verify(transport).unregisterListener(
             TOPIC_URI,
-            TRANSPORT_SOURCE,
+            Optional.of(TRANSPORT_SOURCE),
             listener);
     }
 
     @Test
     @DisplayName("Test unregistering a listener that was not registered")
+    @SuppressWarnings("unchecked")
     void testUnregisterListenerNotRegistered() {
         final var listener = mock(UListener.class);
-        when(transport.unregisterListener(TOPIC_URI, TRANSPORT_SOURCE, listener))
+        when(transport.unregisterListener(any(UUri.class), any(Optional.class), any(UListener.class)))
             .thenReturn(CompletableFuture.failedFuture(
                 new UStatusException(UCode.NOT_FOUND, "no such listener")));
         final var exception = assertThrows(CompletionException.class, () -> {
@@ -124,7 +127,7 @@ class SimpleNotifierTest extends CommunicationLayerClientTestBase {
         });
         verify(transport).unregisterListener(
             TOPIC_URI,
-            TRANSPORT_SOURCE,
+            Optional.of(TRANSPORT_SOURCE),
             listener);
         assertEquals(UCode.NOT_FOUND, ((UStatusException) exception.getCause()).getCode());
     }

--- a/src/test/java/org/eclipse/uprotocol/communication/UClientTest.java
+++ b/src/test/java/org/eclipse/uprotocol/communication/UClientTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.uprotocol.transport.StaticUriProvider;
@@ -65,11 +66,11 @@ class UClientTest {
     @Test
     void testFactoryMethod() {
         var transport = mock(UTransport.class);
-        when(transport.registerListener(any(UUri.class), any(UUri.class), any(UListener.class)))
+        when(transport.registerListener(any(UUri.class), any(Optional.class), any(UListener.class)))
             .thenReturn(CompletableFuture.completedFuture(null));
         var uriProvider = StaticUriProvider.of(TRANSPORT_SOURCE);
         UClient.create(transport, uriProvider);
-        verify(transport).registerListener(any(UUri.class), eq(TRANSPORT_SOURCE), any(UListener.class));
+        verify(transport).registerListener(any(UUri.class), eq(Optional.of(TRANSPORT_SOURCE)), any(UListener.class));
     }
 
     @Test

--- a/src/test/java/org/eclipse/uprotocol/transport/UTransportTest.java
+++ b/src/test/java/org/eclipse/uprotocol/transport/UTransportTest.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.uprotocol.transport;
 
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -53,20 +54,22 @@ class UTransportTest {
 
     @Test
     @DisplayName("Test default implementation of registerListener")
+    @SuppressWarnings("unchecked")
     void testRegisterListener() {
-        when(transport.registerListener(any(UUri.class), any(UUri.class), any(UListener.class)))
+        when(transport.registerListener(any(UUri.class), any(Optional.class), any(UListener.class)))
             .thenReturn(CompletableFuture.completedFuture(null));
 
         transport.registerListener(SOURCE_FILTER, listener).toCompletableFuture().join();
-        verify(transport).registerListener(eq(SOURCE_FILTER), eq(UriFactory.ANY), eq(listener));
+        verify(transport).registerListener(eq(SOURCE_FILTER), eq(Optional.of(UriFactory.ANY)), eq(listener));
     }
 
     @Test
     @DisplayName("Test happy path unregister listener")
+    @SuppressWarnings("unchecked")
     void testUnregisterListener() {
-        when(transport.unregisterListener(any(UUri.class), any(UUri.class), any(UListener.class)))
+        when(transport.unregisterListener(any(UUri.class), any(Optional.class), any(UListener.class)))
             .thenReturn(CompletableFuture.completedFuture(null));
         transport.unregisterListener(SOURCE_FILTER, listener).toCompletableFuture().join();
-        verify(transport).unregisterListener(eq(SOURCE_FILTER), eq(UriFactory.ANY), eq(listener));
+        verify(transport).unregisterListener(eq(SOURCE_FILTER), eq(Optional.of(UriFactory.ANY)), eq(listener));
     }
 }

--- a/src/test/java/org/eclipse/uprotocol/transport/validator/UAttributesValidatorTest.java
+++ b/src/test/java/org/eclipse/uprotocol/transport/validator/UAttributesValidatorTest.java
@@ -110,7 +110,7 @@ public class UAttributesValidatorTest {
         10000,  true
         29999,  true
         30000,  true
-        30001,  false
+        40000,  false
         """)
     void testIsExpired(int ttl, boolean expectedIsExpired) {
         var now = Instant.now();


### PR DESCRIPTION
The UTransport interface's methods have been updated to be more explicit
about the arguments being passed in. In particular, the methods no longer
accept null values for UUri parameters.

Also added a helper method for validating filter URIs that are being
used for registering listeners.