### PR TITLE
Fix usage of unsigned integers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -377,23 +377,14 @@
                         <configuration>
                             <!-- Exclude classes generated from proto3 files -->
                             <excludes>
+                                <exclude>org/eclipse/uprotocol/Uoptions.*</exclude>
+                                <exclude>org/eclipse/uprotocol/UServiceTopic*</exclude>
                                 <exclude>org/eclipse/uprotocol/core/**</exclude>
                                 <exclude>org/eclipse/uprotocol/v1/**</exclude>
                             </excludes>
                         </configuration>
                     </execution>
                 </executions>
-                <configuration>
-                    <includes>
-                        <include>**/client/**</include>
-                        <include>**/cloudevent/**</include>
-                        <include>**/communication/**</include>
-                        <include>**/transport/**</include>
-                        <include>**/uri/**</include>
-                        <include>**/uuid/**</include>
-                        <include>**/validation/**</include>
-                    </includes>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.sonatype.central</groupId>

--- a/src/main/java/org/eclipse/uprotocol/transport/builder/UMessageBuilder.java
+++ b/src/main/java/org/eclipse/uprotocol/transport/builder/UMessageBuilder.java
@@ -55,7 +55,7 @@ public final class UMessageBuilder {
 
     /**
      * Gets a builder for a publish message.
-     *
+     * <p>
      * A publish message is used to notify all interested consumers of an event that has occurred.
      * Consumers usually indicate their interest by <em>subscribing</em> to a particular topic.
      *
@@ -75,7 +75,7 @@ public final class UMessageBuilder {
 
     /**
      * Gets a builder for a notification message.
-     *
+     * <p>
      * A notification is used to inform a specific consumer about an event that has occurred.
      *
      * @param source The component that the notification originates from.
@@ -135,13 +135,6 @@ public final class UMessageBuilder {
      * <p>
      * The builder will be initialized with {@link UPriority#UPRIORITY_CS4}.
      *
-     * # Arguments
-     *
-     * * `reply_to_address` - The URI that the sender of the request expects to receive the response message at.
-     * * `request_id` - The identifier of the request that this is the response to.
-     * * `invoked_method` - The URI identifying the method that has been invoked and which the created message is
-     *   the outcome of.
-     *
      * @param source The URI identifying the method that has been invoked and which the created message is
      *   the outcome of.
      * @param sink   The URI that the sender of the request expects to receive the response message at.
@@ -169,16 +162,9 @@ public final class UMessageBuilder {
      * <p>
      * A response message is used to send the outcome of processing a request message
      * to the original sender of the request message.
-     * <p>
-     * The builder will be initialized with values from the given request attributes.
      *
-     * # Arguments
-     *
-     * * `request_attributes` - The attributes from the request message. The response message
-     *   builder will be initialized with the corresponding attribute values.
-     * 
      * @param request The attributes from the request message. The response message
-     *   builder will be initialized with the corresponding attribute values.
+     * builder will be initialized with the corresponding attribute values.
      * @return The builder.
      * @throws NullPointerException if request is {@code null}.
      * @throws IllegalArgumentException if the request does not contain valid request attributes.
@@ -219,7 +205,7 @@ public final class UMessageBuilder {
 
     /**
      * Sets the message's identifier.
-     *
+     * <p>
      * Every message must have an identifier. If this method is not used, an identifier will be
      * generated and set on the message when one of the <em>build</em> methods is invoked.
      *
@@ -241,14 +227,11 @@ public final class UMessageBuilder {
     /**
      * Sets the message's time-to-live.
      *
-     * @param ttl The time-to-live in milliseconds.
+     * @param ttl The time-to-live in milliseconds. Note that the value is interpreted as an
+     * <em>unsigned</em> integer. A value of 0 indicates that the message never expires.
      * @return The builder with the configured ttl.
-     * @throws IllegalArgumentException if the ttl is negative.
      */
     public UMessageBuilder withTtl(int ttl) {
-        if (ttl < 0) {
-            throw new IllegalArgumentException("TTL must be a non-negative integer.");
-        }
         this.ttl = ttl;
         return this;
     }
@@ -296,16 +279,12 @@ public final class UMessageBuilder {
     /**
      * Sets the message's permission level.
      *
-     * @param plevel The level.
+     * @param plevel The level. Note that the value is interpreted as an <em>unsigned</em> integer.
      * @return The builder with the configured permission level.
-     * @throws IllegalArgumentException if the permission level is less than 0.
      * @throws IllegalStateException if the message is not an RPC request message.
      */
     public UMessageBuilder withPermissionLevel(int plevel) {
         // [impl->dsn~up-attributes-permission-level~1]
-        if (plevel < 0) {
-            throw new IllegalArgumentException("Permission level must be greater than or equal to 0.");
-        }
         if (this.type != UMessageType.UMESSAGE_TYPE_REQUEST) {
             throw new IllegalStateException("Permission level can only be set for RPC request messages.");
         }
@@ -371,11 +350,6 @@ public final class UMessageBuilder {
     
     /**
      * Creates the message based on the builder's state.
-     *
-     * # Errors
-     *
-     * If the properties set on the builder do not represent a consistent set of [`UAttributes`],
-     * a [`UMessageError::AttributesValidationError`] is returned.
      *
      * @return A message ready to be sent using a transport implementation.
      * @throws ValidationException if the properties set on the builder do not represent a

--- a/src/test/java/org/eclipse/uprotocol/communication/InMemoryRpcClientTest.java
+++ b/src/test/java/org/eclipse/uprotocol/communication/InMemoryRpcClientTest.java
@@ -187,6 +187,7 @@ class InMemoryRpcClientTest extends CommunicationLayerClientTestBase {
                 METHOD_URI,
                 TRANSPORT_SOURCE,
                 reqId)
+            .withTtl(54321)
             .build();
         responseListener.getValue().onReceive(responseMessage);
 

--- a/src/test/java/org/eclipse/uprotocol/transport/validator/UAttributesValidatorTest.java
+++ b/src/test/java/org/eclipse/uprotocol/transport/validator/UAttributesValidatorTest.java
@@ -563,16 +563,6 @@ public class UAttributesValidatorTest {
                 OptionalInt.of(0),
                 OptionalInt.of(UPriority.UPRIORITY_CS4_VALUE),
                 Optional.empty(),
-                false),
-            // fails for invalid (negative) permission level
-            Arguments.of(
-                Optional.of(UuidFactory.create()),
-                Optional.of(UURI_METHOD),
-                Optional.of(UURI_DEFAULT),
-                OptionalInt.of(-1),
-                OptionalInt.of(2000),
-                OptionalInt.of(UPriority.UPRIORITY_CS4_VALUE),
-                Optional.empty(),
                 false)
         );
     }
@@ -629,7 +619,7 @@ public class UAttributesValidatorTest {
                 Optional.of(UURI_METHOD),
                 Optional.of(UuidFactory.create()),
                 OptionalInt.empty(),
-                OptionalInt.empty(),
+                OptionalInt.of(100),
                 Optional.of(UPriority.UPRIORITY_CS4),
                 true),
             // succeeds for valid attributes
@@ -661,7 +651,7 @@ public class UAttributesValidatorTest {
                 Optional.of(UURI_METHOD),
                 Optional.of(UuidFactory.create()),
                 OptionalInt.empty(),
-                OptionalInt.empty(),
+                OptionalInt.of(100),
                 Optional.of(UPriority.UPRIORITY_CS4),
                 false),
             // fails for missing reply-to-address
@@ -672,7 +662,7 @@ public class UAttributesValidatorTest {
                 Optional.of(UURI_METHOD),
                 Optional.of(UuidFactory.create()),
                 OptionalInt.empty(),
-                OptionalInt.empty(),
+                OptionalInt.of(100),
                 Optional.of(UPriority.UPRIORITY_CS4),
                 false),
             // fails for invalid reply-to-address
@@ -683,7 +673,7 @@ public class UAttributesValidatorTest {
                 Optional.of(UURI_METHOD),
                 Optional.of(UuidFactory.create()),
                 OptionalInt.empty(),
-                OptionalInt.empty(),
+                OptionalInt.of(100),
                 Optional.of(UPriority.UPRIORITY_CS4),
                 false),
             // fails for reply-to-address with wildcard
@@ -694,7 +684,7 @@ public class UAttributesValidatorTest {
                 Optional.of(UURI_METHOD),
                 Optional.of(UuidFactory.create()),
                 OptionalInt.empty(),
-                OptionalInt.empty(),
+                OptionalInt.of(100),
                 Optional.of(UPriority.UPRIORITY_CS4),
                 false),
             // fails for missing invoked-method
@@ -705,7 +695,7 @@ public class UAttributesValidatorTest {
                 Optional.empty(),
                 Optional.of(UuidFactory.create()),
                 OptionalInt.empty(),
-                OptionalInt.empty(),
+                OptionalInt.of(100),
                 Optional.of(UPriority.UPRIORITY_CS4),
                 false),
             // fails for invalid invoked-method
@@ -716,7 +706,7 @@ public class UAttributesValidatorTest {
                 Optional.of(UURI_TOPIC),
                 Optional.of(UuidFactory.create()),
                 OptionalInt.empty(),
-                OptionalInt.empty(),
+                OptionalInt.of(100),
                 Optional.of(UPriority.UPRIORITY_CS4),
                 false),
             // fails for invoked-method with wildcard
@@ -727,7 +717,7 @@ public class UAttributesValidatorTest {
                 Optional.of(UURI_WILDCARD_RESOURCE),
                 Optional.of(UuidFactory.create()),
                 OptionalInt.empty(),
-                OptionalInt.empty(),
+                OptionalInt.of(100),
                 Optional.of(UPriority.UPRIORITY_CS4),
                 false),
             // fails for invalid commstatus
@@ -737,20 +727,10 @@ public class UAttributesValidatorTest {
                 Optional.of(UURI_METHOD),
                 Optional.of(UuidFactory.create()),
                 OptionalInt.of(-189),
-                OptionalInt.empty(),
-                Optional.of(UPriority.UPRIORITY_CS4),
-                false),
-            // succeeds for ttl > 0
-            Arguments.of(
-                Optional.of(UuidFactory.create()),
-                Optional.of(UURI_DEFAULT),
-                Optional.of(UURI_METHOD),
-                Optional.of(UuidFactory.create()),
-                OptionalInt.empty(),
                 OptionalInt.of(100),
                 Optional.of(UPriority.UPRIORITY_CS4),
-                true),
-            // succeeds for ttl = 0
+                false),
+            // fails for ttl = 0
             Arguments.of(
                 Optional.of(UuidFactory.create()),
                 Optional.of(UURI_DEFAULT),
@@ -759,7 +739,7 @@ public class UAttributesValidatorTest {
                 OptionalInt.empty(),
                 OptionalInt.of(0),
                 Optional.of(UPriority.UPRIORITY_CS4),
-                true),
+                false),
             // fails for missing priority
             Arguments.of(
                 Optional.of(UuidFactory.create()),

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -8,5 +8,5 @@
     <root level="INFO">
         <appender-ref ref="STDOUT" />
     </root>
-    <logger name="org.eclipse.uprotocol.communication" level="INFO" />
+    <logger name="org.eclipse.uprotocol" level="DEBUG" />
 </configuration>


### PR DESCRIPTION
Some of the UAttributes properties are defined as unsigned integers in
the protocol specification. However, Java does not have native support for
unsigned types, which can lead to issues when dealing with values that exceed
the maximum value of a signed integer.

Java 8 has introduced support for handling unsigned integers through methods
in the Integer and Long classes. This commit updates the codebase to utilize
these methods where appropriate, ensuring that unsigned integer values are
handled correctly.