### PR TITLE
Move validation of authority to UriValidator

### DIFF
--- a/src/test/java/org/eclipse/uprotocol/uri/serializer/UriSerializerTest.java
+++ b/src/test/java/org/eclipse/uprotocol/uri/serializer/UriSerializerTest.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.uprotocol.uri.serializer;
 
+import org.eclipse.uprotocol.uri.validator.UriValidator;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -21,8 +22,6 @@ import java.net.URI;
 
 
 class UriSerializerTest {
-
-    private static final int AUTHORITY_NAME_MAX_LENGTH = 128;
 
     @Test
     @DisplayName("Test serializing a null UUri fails")
@@ -41,11 +40,11 @@ class UriSerializerTest {
     @DisplayName("Test deserializing a UUri with authority name exceeding max length fails")
     // [utest->dsn~uri-authority-name-length~1]
     void testDeserializeRejectsAuthorityNameExceedingMaxLength() {
-        String authority = "a".repeat(AUTHORITY_NAME_MAX_LENGTH);
+        String authority = "a".repeat(UriValidator.AUTHORITY_NAME_MAX_LENGTH);
         String validUri = "up://%s/ABCD/1/1001".formatted(authority);
         assertDoesNotThrow(() -> UriSerializer.deserialize(validUri));
 
-        authority = "a".repeat(AUTHORITY_NAME_MAX_LENGTH + 1);
+        authority = "a".repeat(UriValidator.AUTHORITY_NAME_MAX_LENGTH + 1);
         var invalidUri = "up://%s/ABCD/1/1001".formatted(authority);
         assertThrows(IllegalArgumentException.class, () -> UriSerializer.deserialize(invalidUri));
     }

--- a/src/test/resources/features/uuri_uri_serialization.feature
+++ b/src/test/resources/features/uuri_uri_serialization.feature
@@ -78,6 +78,7 @@ Feature: String representation of endpoint identfiers (UUri)
       | "xy://vcu.my_vin/101/1/A"             | unsupported schema                                    |
       | "//vcu.my_vin/101/1/A?foo=bar"        | URI with query                                        |
       | "//vcu.my_vin/101/1/A#foo"            | URI with fragment                                     |
+      | "//VCU.my-vin/101/1/A"                | server-based authority with upper-case letters        |
       | "//vcu.my-vin:1516/101/1/A"           | server-based authority with port                      |
       | "//user:pwd@vcu.my-vin/101/1/A"       | server-based authority with user info                 |
       | "//[2001:db87aa::8]/101/1/A"          | invalid IP literal authority                          |


### PR DESCRIPTION
The code for validating the authority component of a uProtocol URI has
been moved from the UriSerializer class to the UriValidator class.

This change centralizes the validation logic, making it easier to
maintain and ensuring consistent validation across different parts
of the codebase.